### PR TITLE
Admin: add a new column to display post views

### DIFF
--- a/class-jeherve-post-views-admin-cols.php
+++ b/class-jeherve-post-views-admin-cols.php
@@ -45,12 +45,12 @@ class Jeherve_Post_Views_Admin_Cols {
 
 		if ( 'views' === $column_name ) {
 			$view_count = ! empty( $views ) && isset( $views['total'] )
-				? $views['total']
-				: 0;
+				? number_format_i18n( $views['total'] )
+				: '—';
 
 			printf(
 				'<span class="view-count">%s</span>',
-				number_format_i18n( (int) $view_count )
+				esc_html( $view_count )
 			);
 		}
 	}

--- a/class-jeherve-post-views-admin-cols.php
+++ b/class-jeherve-post-views-admin-cols.php
@@ -41,6 +41,8 @@ class Jeherve_Post_Views_Admin_Cols {
 	 * @param int    $post_id - the post id.
 	 */
 	public static function view_count_edit_column( $column_name, $post_id ) {
+		require_once JPPOSTVIEWS__PLUGIN_DIR . 'functions.jp-post-views.php';
+
 		$views = jp_post_views_get_view( $post_id );
 
 		if ( 'views' === $column_name ) {

--- a/class-jeherve-post-views-admin-cols.php
+++ b/class-jeherve-post-views-admin-cols.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Add a new column to post and page admin screens, displaying the number of views.
+ *
+ * @since 1.6.0
+ *
+ * @package Post_Views_For_Jetpack
+ */
+
+/**
+ * Jeherve_Post_Views_Admin_Cols class.
+ */
+class Jeherve_Post_Views_Admin_Cols {
+	/**
+	 * Add a new column to post and page admin screens, displaying the number of views.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param array $columns - array of columns in wp-admin.
+	 */
+	public static function add_view_count_column( $columns ) {
+		$stats = $columns['stats'];
+		unset( $columns['stats'] );
+
+		$columns['stats'] = $stats;
+		$columns['views'] = esc_html__( 'Views', 'post-views-for-jetpack' );
+
+		return $columns;
+	}
+
+	/**
+	 * Add "Likes" column data to the post edit table in wp-admin.
+	 *
+	 * @param string $column_name - name of the column.
+	 * @param int    $post_id - the post id.
+	 */
+	public static function view_count_edit_column( $column_name, $post_id ) {
+		$views = jp_post_views_get_view( $post_id );
+
+		if ( 'views' === $column_name ) {
+			$view_count = ! empty( $views ) && isset( $views['total'] )
+				? $views['total']
+				: 0;
+
+			printf(
+				'<span class="view-count">%s</span>',
+				number_format_i18n( (int) $view_count )
+			);
+		}
+	}
+}

--- a/class-jeherve-post-views-admin-cols.php
+++ b/class-jeherve-post-views-admin-cols.php
@@ -19,10 +19,16 @@ class Jeherve_Post_Views_Admin_Cols {
 	 * @param array $columns - array of columns in wp-admin.
 	 */
 	public static function add_view_count_column( $columns ) {
-		$stats = $columns['stats'];
-		unset( $columns['stats'] );
+		/*
+		 * Place our colunm right after the Stats column.
+		 * by reorganizing the array a bit.
+		 */
+		if ( isset( $columns['stats'] ) ) {
+			$stats = $columns['stats'];
+			unset( $columns['stats'] );
+			$columns['stats'] = $stats;
+		}
 
-		$columns['stats'] = $stats;
 		$columns['views'] = esc_html__( 'Views', 'post-views-for-jetpack' );
 
 		return $columns;

--- a/jp-post-views.php
+++ b/jp-post-views.php
@@ -40,6 +40,9 @@ class Jeherve_Jp_Post_Views {
 	private function __construct() {
 		// Load plugin.
 		add_action( 'plugins_loaded', array( $this, 'load_plugin' ) );
+
+		// Load Admin features.
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
 	}
 
 	/**
@@ -71,6 +74,17 @@ class Jeherve_Jp_Post_Views {
 			// Prompt the user to install Jetpack.
 			add_action( 'admin_notices',  array( $this, 'install_jetpack' ) );
 		}
+	}
+
+	/** Initialize admin settings */
+	public function admin_init() {
+		// Load our functions.
+		require_once( JPPOSTVIEWS__PLUGIN_DIR . 'class-jeherve-post-views-admin-cols.php' );
+
+		add_filter( 'manage_posts_columns', array( 'Jeherve_Post_Views_Admin_Cols', 'add_view_count_column' ) );
+		add_filter( 'manage_pages_columns', array( 'Jeherve_Post_Views_Admin_Cols', 'add_view_count_column' ) );
+		add_action( 'manage_posts_custom_column', array( 'Jeherve_Post_Views_Admin_Cols', 'view_count_edit_column' ), 10, 2 );
+		add_action( 'manage_pages_custom_column', array( 'Jeherve_Post_Views_Admin_Cols', 'view_count_edit_column' ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5

## Proposed changes:

- Admin: add a new column to display post views

This works, but considerably slows down the admin since it needs to make 20 calls to the WordPress.com REST API every time you load the post list. It can even be more if you've changed the number of posts displayed on each post list page.

It will make less calls when stats are cached for a post of course, but the cache is only valid for an hour by default, so in practice folks will experience slowness. **I do not think this can be shipped as it is**.

