### PR TITLE
Admin: add a new column to display post views

### DIFF
--- a/class-jeherve-post-views-admin-cols.php
+++ b/class-jeherve-post-views-admin-cols.php
@@ -20,8 +20,10 @@ class Jeherve_Post_Views_Admin_Cols {
 	 */
 	public static function add_view_count_column( $columns ) {
 		/*
-		 * Place our colunm right after the Stats column.
-		 * by reorganizing the array a bit.
+		 * Place our colunm right after Jetpack's own Stats column.
+		 * Jetpack's Stats column and our "views" column are related, after all.
+		 * They need to be close to each other.
+		 * Let's reorganize the array a bit.
 		 */
 		if ( isset( $columns['stats'] ) ) {
 			$stats = $columns['stats'];

--- a/class-jeherve-post-views-admin-cols.php
+++ b/class-jeherve-post-views-admin-cols.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Add a new column to post and page admin screens, displaying the number of views.
+ *
+ * @since 2.0.0
+ *
+ * @package Post_Views_For_Jetpack
+ */
+
+/**
+ * Jeherve_Post_Views_Admin_Cols class.
+ */
+class Jeherve_Post_Views_Admin_Cols {
+	/**
+	 * Add a new column to post and page admin screens, displaying the number of views.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $columns - array of columns in wp-admin.
+	 */
+	public static function add_view_count_column( $columns ) {
+		/*
+		 * Place our colunm right after the Stats column.
+		 * by reorganizing the array a bit.
+		 */
+		if ( isset( $columns['stats'] ) ) {
+			$stats = $columns['stats'];
+			unset( $columns['stats'] );
+			$columns['stats'] = $stats;
+		}
+		$columns['views'] = esc_html__( 'Views', 'post-views-for-jetpack' );
+
+		return $columns;
+	}
+
+	/**
+	 * Add "Likes" column data to the post edit table in wp-admin.
+	 *
+	 * @param string $column_name - name of the column.
+	 * @param int    $post_id - the post id.
+	 */
+	public static function view_count_edit_column( $column_name, $post_id ) {
+		require_once JPPOSTVIEWS__PLUGIN_DIR . 'functions.jp-post-views.php';
+		$views = jp_post_views_get_view( $post_id );
+
+		if ( 'views' === $column_name ) {
+			$view_count = ! empty( $views )
+				? number_format_i18n( $views )
+				: '—';
+
+			printf(
+				'<span class="view-count">%s</span>',
+				esc_html( $view_count )
+			);
+		}
+	}
+}

--- a/functions.jp-post-views.php
+++ b/functions.jp-post-views.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Stats\WPCOM_Stats;
 function jp_post_views_get_view( $post_id ) {
 	/**
 	 * Allow setting up your own duration for the cache.
-	 * 
+	 *
 	 * @deprecated 2.0.0 This filter is no longer necessary, it is done within the Jetpack plugin now.
 	 *
 	 * @since 1.5.0

--- a/functions.jp-post-views.php
+++ b/functions.jp-post-views.php
@@ -24,16 +24,23 @@ function jp_post_views_get_view( $post_id ) {
 	 * @deprecated 2.0.0 This filter is no longer necessary, it is done within the Jetpack plugin now.
 	 *
 	 * @since 1.5.0
+	 * @since 2.0.0 Use jetpack_fetch_stats_cache_expiration instead. Default changes to 5 minutes.
 	 *
-	 * @param int $duration The duration of the cache in seconds. Default to an hour.
+	 * @param int $duration The duration of the cache in seconds. Default to an hour in the past, now 5 minutes.
 	 */
 	$cache_duration = (int) apply_filters_deprecated(
 		'jp_post_views_cache_duration',
-		array( HOUR_IN_SECONDS ),
-		'2.0.0',
 		'',
-		esc_html__( 'Caching this data is no longer necessary, it is done within the Jetpack plugin now.', 'post-views-for-jetpack' )
+		'2.0.0',
+		'jetpack_fetch_stats_cache_expiration',
+		esc_html__( 'You can now cache the data within the Jetpack plugin now, by specifying a number of minutes.', 'post-views-for-jetpack' )
 	);
+	if ( ! empty( $cache_duration ) ) {
+		add_filter( 'jetpack_fetch_stats_cache_expiration', function() use ( $cache_duration ) {
+			return $cache_duration / MINUTE_IN_SECONDS;
+		} );
+	}
+	
 
 	// Get the data for a specific post.
 	$stats = jp_post_views_convert_stats_array_to_object(

--- a/functions.jp-post-views.php
+++ b/functions.jp-post-views.php
@@ -15,56 +15,32 @@ use Automattic\Jetpack\Stats\WPCOM_Stats;
  *
  * @param string $post_id Post ID.
  *
- * @return array $view Post View.
+ * @return int $view Post View.
  */
 function jp_post_views_get_view( $post_id ) {
-	// Check if we have cached data.
-	$cached_view = get_post_meta( $post_id, '_post_views', true );
-
 	/**
 	 * Allow setting up your own duration for the cache.
+	 * 
+	 * @deprecated 2.0.0 This filter is no longer necessary, it is done within the Jetpack plugin now.
 	 *
 	 * @since 1.5.0
 	 *
 	 * @param int $duration The duration of the cache in seconds. Default to an hour.
 	 */
-	$cache_duration = (int) apply_filters( 'jp_post_views_cache_duration', HOUR_IN_SECONDS );
-
-	// Current date timestamp.
-	$now = current_datetime()->getTimestamp();
-
-	// If we have cached data recently, return that data.
-	if (
-		! empty( $cached_view )
-		&& isset( $cached_view['cached_date'] )
-		&& ( $now - (int) $cached_view['cached_date'] ) < $cache_duration
-	) {
-		return $cached_view;
-	}
-
-	// If no cached data, or stale cached data, start with an empty array.
-	$view = array();
+	$cache_duration = (int) apply_filters_deprecated(
+		'jp_post_views_cache_duration',
+		array( HOUR_IN_SECONDS ),
+		'2.0.0',
+		'',
+		esc_html__( 'Caching this data is no longer necessary, it is done within the Jetpack plugin now.', 'post-views-for-jetpack' )
+	);
 
 	// Get the data for a specific post.
 	$stats = jp_post_views_convert_stats_array_to_object(
-		( new WPCOM_Stats() )->get_post_views( (int) $post_id )
+		( new WPCOM_Stats() )->get_post_views( (int) $post_id, array( 'fields' => 'views' ), true )
 	);
 
-	// Process that data.
-	if (
-		isset( $stats )
-		&& ! empty( $stats )
-		&& isset( $stats->views )
-	) {
-		$view = array(
-			'total'       => $stats->views,
-			'cached_at'   => isset( $stats->cached_at ) ? $stats->cached_at : '', // @to-do: deprecate this. We now use the cached_date below.
-			'cached_date' => $now,
-		);
-		update_post_meta( $post_id, '_post_views', $view );
-	}
-
-	return $view;
+	return $stats->views ?? 0;
 }
 
 /**
@@ -72,29 +48,15 @@ function jp_post_views_get_view( $post_id ) {
  *
  * @since 1.0.0
  *
- * @return string $views All time views for that site.
+ * @return int $views All time views for that site.
  */
 function jp_post_views_get_all_views() {
-	// Start with an empty array.
-	$views = array();
-
 	// Get the data.
 	$stats = jp_post_views_convert_stats_array_to_object(
 		( new WPCOM_Stats() )->get_stats( array( 'fields' => 'stats' ) )
 	);
 
-	if (
-		isset( $stats )
-		&& ! empty( $stats )
-		&& isset( $stats->stats )
-	) {
-		$views = array(
-			'total'     => $stats->stats->views,
-			'cached_at' => isset( $stats->cached_at ) ? $stats->cached_at : '',
-		);
-	}
-
-	return $views;
+	return $stats->stats->views ?? 0;
 }
 
 /**
@@ -108,25 +70,23 @@ function jp_post_views_get_all_views() {
 function jp_post_views_display() {
 	// Get the post ID.
 	$post_id = get_the_ID();
-
-	if ( ! isset( $post_id ) || empty( $post_id ) ) {
+	if ( empty( $post_id ) ) {
 		return;
 	}
 
 	// Get the number of views for that post.
 	$views = jp_post_views_get_view( $post_id );
-
-	if ( isset( $views ) && ! empty( $views ) ) {
+	if ( ! empty( $views ) ) {
 		$view = sprintf(
 			esc_html(
 				_n(
 					'%s view',
 					'%s views',
-					$views['total'],
+					$views,
 					'post-views-for-jetpack'
 				)
 			),
-			number_format_i18n( $views['total'] )
+			number_format_i18n( $views )
 		);
 	} else {
 		$view = esc_html__( 'no views', 'post-views-for-jetpack' );

--- a/jp-post-views.php
+++ b/jp-post-views.php
@@ -73,6 +73,7 @@ class Jeherve_Jp_Post_Views {
 		// Load plugin.
 		require_once( JPPOSTVIEWS__PLUGIN_DIR . 'functions.jp-post-views.php' );
 		require_once( JPPOSTVIEWS__PLUGIN_DIR . 'widgets.jp-post-views.php' );
+		require_once( JPPOSTVIEWS__PLUGIN_DIR . 'class-jeherve-post-views-admin-cols.php' );
 
 		// Add Stats to REST API Post response.
 		if ( function_exists( 'register_rest_field' ) ) {
@@ -81,6 +82,12 @@ class Jeherve_Jp_Post_Views {
 
 		// Create shortcode.
 		add_shortcode( 'jp_post_view', 'jp_post_views_display' );
+
+		// Add a new column to post and page admin screens, displaying the number of views.
+		add_filter( 'manage_posts_columns', array( 'Jeherve_Post_Views_Admin_Cols', 'add_view_count_column' ) );
+		add_filter( 'manage_pages_columns', array( 'Jeherve_Post_Views_Admin_Cols', 'add_view_count_column' ) );
+		add_action( 'manage_posts_custom_column', array( 'Jeherve_Post_Views_Admin_Cols', 'view_count_edit_column' ), 10, 2 );
+		add_action( 'manage_pages_custom_column', array( 'Jeherve_Post_Views_Admin_Cols', 'view_count_edit_column' ), 10, 2 );
 	}
 
 	/**

--- a/jp-post-views.php
+++ b/jp-post-views.php
@@ -84,10 +84,10 @@ class Jeherve_Jp_Post_Views {
 		add_shortcode( 'jp_post_view', 'jp_post_views_display' );
 
 		// Add a new column to post and page admin screens, displaying the number of views.
-		add_filter( 'manage_posts_columns', array( 'Jeherve_Post_Views_Admin_Cols', 'add_view_count_column' ) );
-		add_filter( 'manage_pages_columns', array( 'Jeherve_Post_Views_Admin_Cols', 'add_view_count_column' ) );
-		add_action( 'manage_posts_custom_column', array( 'Jeherve_Post_Views_Admin_Cols', 'view_count_edit_column' ), 10, 2 );
-		add_action( 'manage_pages_custom_column', array( 'Jeherve_Post_Views_Admin_Cols', 'view_count_edit_column' ), 10, 2 );
+		add_filter( 'manage_posts_columns', array( 'Jeherve_Post_Views_Admin_Cols', 'add_view_count_column' ), 20 );
+		add_filter( 'manage_pages_columns', array( 'Jeherve_Post_Views_Admin_Cols', 'add_view_count_column' ), 20 );
+		add_action( 'manage_posts_custom_column', array( 'Jeherve_Post_Views_Admin_Cols', 'view_count_edit_column' ), 20, 2 );
+		add_action( 'manage_pages_custom_column', array( 'Jeherve_Post_Views_Admin_Cols', 'view_count_edit_column' ), 20, 2 );
 	}
 
 	/**

--- a/jp-post-views.php
+++ b/jp-post-views.php
@@ -4,19 +4,19 @@
  * Plugin URI: https://jeremy.hu/jetpack-post-views/
  * Description: Display the number of views for each one of your posts, as recorded by Jetpack Stats.
  * Author: Jeremy Herve
- * Version: 1.5.0
+ * Version: 2.0.0
  * Author URI: https://jeremy.hu
  * License: GPL2+
  *
- * Requires at least: 6.0
- * Requires PHP: 5.6
+ * Requires at least: 6.4
+ * Requires PHP: 7.0
  *
  * @package Post Views for Jetpack
  */
 
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
-define( 'JPPOSTVIEWS__VERSION', '1.5.0' );
+define( 'JPPOSTVIEWS__VERSION', '2.0.0' );
 define( 'JPPOSTVIEWS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 /**
@@ -48,29 +48,39 @@ class Jeherve_Jp_Post_Views {
 	 * @since 1.0.0
 	 */
 	public function load_plugin() {
-		// Check if Jetpack is active, and if the Stats module is used.
-		if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'stats' ) ) {
-			if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '11.5', '<' ) ) {
-				// Prompt the user to update Jetpack.
-				add_action( 'admin_notices',  array( $this, 'update_jetpack' ) );
-				return;
-			}
-
-			// Load our functions.
-			require_once( JPPOSTVIEWS__PLUGIN_DIR . 'functions.jp-post-views.php' );
-			require_once( JPPOSTVIEWS__PLUGIN_DIR . 'widgets.jp-post-views.php' );
-
-			// Add Stats to REST API Post response.
-			if ( function_exists( 'register_rest_field' ) ) {
-				add_action( 'rest_api_init',  array( $this, 'rest_register_post_views' ) );
-			}
-
-			// Create shortcode.
-			add_shortcode( 'jp_post_view', 'jp_post_views_display' );
-		} else {
+		if ( ! class_exists( 'Jetpack' ) ) {
 			// Prompt the user to install Jetpack.
 			add_action( 'admin_notices',  array( $this, 'install_jetpack' ) );
+			return;
 		}
+
+		// Prompt to update Jetpack if necessary.
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.0', '<' ) ) {
+			// Prompt the user to update Jetpack.
+			add_action( 'admin_notices',  array( $this, 'update_jetpack' ) );
+			return;
+		}
+
+
+		// Prompt the user to activate the Stats module if it's not active.
+		$jetpack_modules   = new Automattic\Jetpack\Modules();
+		$stats_active      = $jetpack_modules->is_active( 'stats' );
+		if ( ! $stats_active ) {
+			add_action( 'admin_notices',  array( $this, 'activate_stats' ) );
+			return;
+		}
+
+		// Load plugin.
+		require_once( JPPOSTVIEWS__PLUGIN_DIR . 'functions.jp-post-views.php' );
+		require_once( JPPOSTVIEWS__PLUGIN_DIR . 'widgets.jp-post-views.php' );
+
+		// Add Stats to REST API Post response.
+		if ( function_exists( 'register_rest_field' ) ) {
+			add_action( 'rest_api_init',  array( $this, 'rest_register_post_views' ) );
+		}
+
+		// Create shortcode.
+		add_shortcode( 'jp_post_view', 'jp_post_views_display' );
 	}
 
 	/**
@@ -96,8 +106,22 @@ class Jeherve_Jp_Post_Views {
 	public function install_jetpack() {
 		echo '<div class="error"><p>';
 		printf(
-			__( 'To use the Post View for Jetpack plugin, you\'ll need to install and activate <a href="%s">Jetpack</a> first, and then activate the Stats module.', 'post-views-for-jetpack' ),
+			__( 'To use the Post Views for Jetpack plugin, you\'ll need to install and activate <a href="%s">Jetpack</a> first, and then activate the Stats module.', 'post-views-for-jetpack' ),
 			'plugin-install.php?tab=search&s=jetpack&plugin-search-input=Search+Plugins'
+		);
+		echo '</p></div>';
+	}
+
+	/**
+	 * Prompt to activate the Stats module.
+	 *
+	 * @since 2.0.0
+	 */
+	public function activate_stats() {
+		echo '<div class="error"><p>';
+		printf(
+			__( 'To use the Post Views for Jetpack plugin, <a href="%s">you\'ll need to activate Jetpack’s Stats feature</a>.', 'post-views-for-jetpack' ),
+			'admin.php?page=jetpack#/traffic?term=stats'
 		);
 		echo '</p></div>';
 	}

--- a/jp-post-views.php
+++ b/jp-post-views.php
@@ -55,7 +55,7 @@ class Jeherve_Jp_Post_Views {
 		}
 
 		// Prompt to update Jetpack if necessary.
-		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.0', '<' ) ) {
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '13.1', '<' ) ) {
 			// Prompt the user to update Jetpack.
 			add_action( 'admin_notices',  array( $this, 'update_jetpack' ) );
 			return;

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ This is still a work in progress, and I would love to know what you'd like this 
 == Changelog ==
 
 = 2.0.0 =
-Release Date: February 2, 2024
+Release Date: February 7, 2024
 
 * Update the plugin to rely on new Stats functionality introduced in Jetpack 13.0.
 * Deprecate the `jp_post_views_cache_duration` filter. The plugin now fully relies on Jetpack's caching mechanism.

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ Release Date: February 2, 2024
 
 * Update the plugin to rely on new Stats functionality introduced in Jetpack 13.0.
 * Deprecate the `jp_post_views_cache_duration` filter. The plugin now fully relies on Jetpack's caching mechanism.
+* Add a new column to post and page admin screens, displaying the number of views.
 
 = 1.5.0 =
 Release Date: February 9, 2023

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Post Views for Jetpack ===
 Contributors: jeherve
 Tags: Stats, Views, Post Views, Jetpack
-Stable tag: 1.5.0
-Requires at least: 6.0
-Tested up to: 6.2
+Stable tag: 2.0.0
+Requires at least: 6.4
+Tested up to: 6.5
 
 Display the number of views for each one of your posts, as recorded by Jetpack Stats.
 
@@ -30,6 +30,12 @@ This is still a work in progress, and I would love to know what you'd like this 
 4. You can use a functionality plugin like [this one](https://wordpress.org/plugins/code-snippets/) to add a custom code snippet to your site without making changes to your theme. In that code snippet, you can decide on which pages the post views should be displayed. In [this example](https://gist.github.com/jeherve/6328c232f91977a6924805d93490c152), the counter will be displayed at the bottom of all posts, only on posts pages.
 
 == Changelog ==
+
+= 2.0.0 =
+Release Date: February 2, 2024
+
+* Update the plugin to rely on new Stats functionality introduced in Jetpack 13.0.
+* Deprecate the `jp_post_views_cache_duration` filter. The plugin now fully relies on Jetpack's caching mechanism.
 
 = 1.5.0 =
 Release Date: February 9, 2023

--- a/widgets.jp-post-views.php
+++ b/widgets.jp-post-views.php
@@ -81,17 +81,17 @@ if ( ! class_exists( 'Jp_Post_Views_All_Widget' ) ) {
 			// Get the Site Stats.
 			$views = jp_post_views_get_all_views();
 
-			if ( isset( $views ) && ! empty( $views ) ) {
+			if ( ! empty( $views ) ) {
 				$stats_output = sprintf(
 					esc_html(
 						_n(
 							'%s view',
 							'%s views',
-							$views['total'],
+							$views,
 							'post-views-for-jetpack'
 						)
 					),
-					number_format_i18n( $views['total'] )
+					number_format_i18n( $views )
 				);
 			} else {
 				$stats_output = esc_html__( 'No views', 'post-views-for-jetpack' );
@@ -102,10 +102,10 @@ if ( ! class_exists( 'Jp_Post_Views_All_Widget' ) ) {
 			 *
 			 * @since 1.0.0
 			 *
-			 * @param string $stats_output   Text displayed to show all time stats in the widget.
-			 * @param string $views['total'] Number of Total views on the site.
+			 * @param string $stats_output Text displayed to show all time stats in the widget.
+			 * @param int    $views        Number of Total views on the site.
 			 */
-			echo apply_filters( 'jp_post_views_all_time_stats_ouput', $stats_output, $views['total'] );
+			echo apply_filters( 'jp_post_views_all_time_stats_ouput', $stats_output, $views );
 
 			echo $args['after_widget'];
 		}


### PR DESCRIPTION
Fixes #5
Closes #11

This is another, simpler take of #11. Jetpack recently introduced changes that now make it easier to store stats data in post meta. This should improve performance of fetching stats in wp-admin, and most importantly will not blow up the options table with transients whenever we want to fetch stats for multiple posts at once.

This will still slow down the admin since it needs to make 20 calls to the WordPress.com REST API every time you load the post list for posts that aren't in cache yet. It can even be more if you've changed the number of posts displayed on each post list page. Unfortunately there is not really a way around it.

I will merge this once Jetpack 13.1 is released next week.

This will effectively means that this plugin will now require Jetpack 13.1.